### PR TITLE
Fix bug error in script.php

### DIFF
--- a/script.php
+++ b/script.php
@@ -64,7 +64,7 @@ class PlgEditorsSwitcherInstallerScript extends InstallerScript
 		if (strtolower($type) == 'update')
 		{
 			$manifest         = $this->getItemArray('manifest_cache', '#__extensions', 'name', Factory::getDbo()->quote($parent->getName()));
-			$this->oldRelease = $manifest['version'];
+			$this->oldRelease = $manifest['version'] ?? JVersion::MAJOR_VERSION . '.' . JVersion::MINOR_VERSION;
 		}
 
 		return parent::preflight($type, $parent);


### PR DESCRIPTION
`Warning: Trying to access array offset on value of type null in /gesor.ru/public_html/tmp/install_62f78a1125235/editors_switcher-4.0.0/script.php on line 67`


When installing, gives this error.
I didn’t particularly delve into the logic.
 But the mistake had to be closed
 In the case of NULL, the current version of Joomla will be substituted.

_PS found the old version of this plugin, and the source site is closed. I wanted to pour the old version into my turnip. But he already found a duplicate filled, updated. THANKS ._